### PR TITLE
feat: キャッシュ制御をNext.js設定に追加

### DIFF
--- a/.github/workflows/deploy-culture-web-production.yml
+++ b/.github/workflows/deploy-culture-web-production.yml
@@ -59,3 +59,11 @@ jobs:
 
       - name: Show Output
         run: echo ${{ steps.deploy.outputs.url }}
+
+      # MEMO: Next.js 側できめ細やかなキャッシュ制御をしているので、Cloud CDN 側のキャッシュは無効化しない
+      # - name: Invalidate CDN Cache
+      #   run: |
+      #     gcloud compute url-maps invalidate-cdn-cache culture-web-prod-url-map \
+      #       --path "/*" \
+      #       --project ${{ env.PROJECT_ID }} \
+      #       --async

--- a/.github/workflows/deploy-culture-web-staging.yml
+++ b/.github/workflows/deploy-culture-web-staging.yml
@@ -67,3 +67,11 @@ jobs:
 
       - name: Show Output
         run: echo ${{ steps.deploy.outputs.url }}
+
+      # MEMO: Next.js 側できめ細やかなキャッシュ制御をしているので、Cloud CDN 側のキャッシュは無効化しない
+      # - name: Invalidate CDN Cache
+      #   run: |
+      #     gcloud compute url-maps invalidate-cdn-cache culture-web-staging-url-map \
+      #       --path "/*" \
+      #       --project ${{ env.PROJECT_ID }} \
+      #       --async

--- a/culture-infra/service/culture-web/modules/load-balancer/main.tf
+++ b/culture-infra/service/culture-web/modules/load-balancer/main.tf
@@ -50,7 +50,7 @@ resource "google_compute_backend_service" "backend" {
   dynamic "cdn_policy" {
     for_each = var.enable_cdn ? [1] : []
     content {
-      cache_mode        = "CACHE_ALL_STATIC"
+      cache_mode        = "USE_ORIGIN_HEADERS"
       default_ttl       = 3600  # 1 hour for static content
       max_ttl           = 86400 # 24 hours max
       client_ttl        = 3600  # 1 hour client cache

--- a/culture-web/next.config.ts
+++ b/culture-web/next.config.ts
@@ -1,7 +1,43 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-	output: "standalone",
+  output: "standalone",
+  async headers() {
+    return [
+      // HTML & SSR: キャッシュしない
+      {
+        source: "/((?!_next/).*)", // _next配下以外（必要に応じて除外を追加）
+        headers: [
+          { key: "Cache-Control", value: "no-store" }, // もしくは "s-maxage=0, must-revalidate"
+        ],
+      },
+      // Nextのビルド静的アセット: 長期キャッシュ
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      // public配下でバージョン付きにできないものは短命に
+      {
+        source: "/:file*(svg|png|jpg|jpeg|gif|webp|ico)",
+        headers: [{ key: "Cache-Control", value: "public, max-age=3600" }],
+      },
+      // Next/Image
+      {
+        source: "/_next/image",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, s-maxage=86400, stale-while-revalidate=604800",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
CDN のキャッシュポリシーをオリジンヘッダー利用に変更して、Next.jsのヘッダーによってキャッシュのライフサイクルをコントロールするようにします。この変更により、必要なものだけがCDNにキャッシュされ、Next.jsデプロイ時の明示的なCDNキャッシュクリアを実施する必要がなくなります。Next.jsのCDN上キャッシュ戦略は next.config.ts の headers を見てください。


## 参考

- [Cache-Control](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/Cache-Control) 
- [キャッシュの概要](https://cloud.google.com/cdn/docs/caching?hl=ja)
