### PR TITLE
fix: タグ情報の取得形式を改善し、タグオブジェクトにID、名前、カテゴリを追加

### DIFF
--- a/culture_rails/app/controllers/api/v1/tag_search_histories_controller.rb
+++ b/culture_rails/app/controllers/api/v1/tag_search_histories_controller.rb
@@ -42,7 +42,7 @@ class Api::V1::TagSearchHistoriesController < ApplicationController
         author: article.author,
         content: article.content,
         published_at: article.published_at,
-        tags: article.tags.pluck(:name)
+        tags: article.tags.map { |tag| { id: tag.id, name: tag.name, category: tag.category } }
       }
     end
 

--- a/culture_rails/doc/openapi.yml
+++ b/culture_rails/doc/openapi.yml
@@ -1604,9 +1604,20 @@ paths:
                             tags:
                               type: array
                               items:
-                                type: string
-                              example: ["AI", "startup"]
-                              description: タグ名の配列
+                                type: object
+                                additionalProperties: false
+                                properties:
+                                  id:
+                                    type: integer
+                                    example: 1
+                                  name:
+                                    type: string
+                                    example: "AI"
+                                  category:
+                                    type: string
+                                    example: "tech"
+                                required: [id, name, category]
+                              description: タグID、タグ名、カテゴリのオブジェクト配列
                           required: [id, title, summary, author, content, published_at, tags]
                     required: [articles]
                 required: [success, data]


### PR DESCRIPTION
WebUIの部品数を減らすために、既存の記事一覧返却と検索履歴記事一覧返却のインターフェースを揃えた。